### PR TITLE
feat: add support to deduct change labels from related commits

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -73,6 +73,34 @@ If none of these is set, Semanticore will use `Semanticore Bot` as name and `sem
 To configure the name of the changelog file, you can use the `CHANGELOG_FILE_NAME`. environment variable. If this variable is not set,
 the default value `Changelog.md` will be used.
 
+### Change label synchronization
+
+Semanticore can propagate a `change::...` label to the release MR/PR.
+
+This feature is disabled by default and only becomes active when both settings are configured:
+
+* `SEMANTICORE_CHANGE_LABELS_ENABLED=true`
+* `SEMANTICORE_CHANGE_LABELS` with a CSV list of **at least two** full labels in priority order
+  (highest priority first)
+* `SEMANTICORE_CHANGE_LABEL_DEFAULT` – label returned when nothing matches at all;
+  must be contained in `SEMANTICORE_CHANGE_LABELS`
+
+The default fallback is optional. When not set, no label is added for the no-match case.
+
+Example:
+
+* `SEMANTICORE_CHANGE_LABELS=change::emergency,change::major,change::normal,change::standard`
+
+You can optionally map semantic commit types to change labels:
+
+* `SEMANTICORE_CHANGE_LABEL_MAP=feat=change::normal,chore=change::standard,ops=change::standard`
+
+Use the map to define feature fallback behavior, e.g. map `feat` to `change::normal`.
+
+Each mapped label must be part of `SEMANTICORE_CHANGE_LABELS`, otherwise the feature is disabled.
+
+When active, Semanticore always synchronizes only labels starting with `change::` and keeps all other labels untouched.
+
 ## Using Semanticore
 
 To test Semanticore locally you can run it without an API token to create an example Changelog:

--- a/internal/commit.go
+++ b/internal/commit.go
@@ -24,6 +24,25 @@ const (
 var commitRegexp = regexp.MustCompile(`#?\d*\s*\[?([a-zA-Z]*)\]?\s*([\(\[]([^\]\)]*)[\]\)])?\s*?(!?)(:?)\s*(.*)`)
 var specialChars = strings.NewReplacer("<", "&lt;", ">", "&gt;", "&", "&amp;")
 
+func ExtractPrefixedLabels(msg, prefix string) []string {
+	if prefix == "" {
+		return nil
+	}
+
+	matcher := regexp.MustCompile(regexp.QuoteMeta(strings.ToLower(prefix)) + `[a-z0-9_-]+`)
+	seen := map[string]struct{}{}
+	var labels []string
+	for _, label := range matcher.FindAllString(strings.ToLower(msg), -1) {
+		if _, ok := seen[label]; ok {
+			continue
+		}
+		seen[label] = struct{}{}
+		labels = append(labels, label)
+	}
+
+	return labels
+}
+
 func ParseCommitMessage(msg string) (CommitType, string, string, bool) {
 	match := commitRegexp.FindStringSubmatch(msg)
 	var commitType, scope, description string
@@ -88,6 +107,26 @@ func ParseCommitMessage(msg string) (CommitType, string, string, bool) {
 	commitDescription = specialChars.Replace(commitDescription)
 
 	return typ, scope, commitDescription, major
+}
+
+var issueRefRegex = regexp.MustCompile(`(?:^|\s|[(\[,])#(\d+)`)
+
+// ExtractIssueRefs returns all unique issue numbers referenced in a commit message.
+func ExtractIssueRefs(msg string) []int {
+	seen := map[int]struct{}{}
+	var refs []int
+	for _, match := range issueRefRegex.FindAllStringSubmatch(msg, -1) {
+		n, err := strconv.Atoi(match[1])
+		if err != nil || n < 1 {
+			continue
+		}
+		if _, ok := seen[n]; ok {
+			continue
+		}
+		seen[n] = struct{}{}
+		refs = append(refs, n)
+	}
+	return refs
 }
 
 var releaseCommitRegex = regexp.MustCompile(`^Release (v?)(\d+).(\d+).(\d+)( \(.*\))?$`)

--- a/internal/commit_test.go
+++ b/internal/commit_test.go
@@ -1,6 +1,10 @@
 package internal
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestParseCommit(t *testing.T) {
 	var cases = []struct {
@@ -95,3 +99,21 @@ func TestDetectReleaseCommit(t *testing.T) {
 		}
 	}
 }
+
+func TestExtractPrefixedLabels(t *testing.T) {
+	labels := ExtractPrefixedLabels("feat: x\n\nchange::major and change::major\nCHANGE::EMERGENCY", "change::")
+	assert.Equal(t, []string{"change::major", "change::emergency"}, labels)
+
+	assert.Empty(t, ExtractPrefixedLabels("feat: x", ""))
+}
+
+func TestExtractIssueRefs(t *testing.T) {
+	refs := ExtractIssueRefs("fix: something\n\nCloses #42, related to #123\nalso see #42")
+	assert.Equal(t, []int{42, 123}, refs)
+
+	refs = ExtractIssueRefs("#1 fix: something")
+	assert.Equal(t, []int{1}, refs)
+
+	assert.Empty(t, ExtractIssueRefs("fix: no issue ref here"))
+}
+

--- a/internal/github.go
+++ b/internal/github.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"strings"
 )
 
 type Github struct {
@@ -119,10 +120,57 @@ func (github Github) MergeRequest(target, title, description, labels string) err
 		Body:  description,
 	}
 	if iid > 0 {
-		return github.request(http.MethodPatch, fmt.Sprintf("/pulls/%d", iid), http.StatusOK, data, nil)
+		if err := github.request(http.MethodPatch, fmt.Sprintf("/pulls/%d", iid), http.StatusOK, data, nil); err != nil {
+			return err
+		}
+		return github.syncPullRequestChangeLabels(iid, labels)
 	}
 	data.Head = "semanticore/release"
-	return github.request(http.MethodPost, "/pulls", http.StatusCreated, data, nil)
+	var created struct {
+		IID int `json:"number"`
+	}
+	if err := github.request(http.MethodPost, "/pulls", http.StatusCreated, data, &created); err != nil {
+		return err
+	}
+	return github.syncPullRequestChangeLabels(created.IID, labels)
+}
+
+func (github Github) syncPullRequestChangeLabels(iid int, labels string) error {
+	if iid < 1 {
+		return nil
+	}
+
+	var existingLabels []struct {
+		Name string `json:"name"`
+	}
+	if err := github.request(http.MethodGet, fmt.Sprintf("/issues/%d/labels", iid), http.StatusOK, nil, &existingLabels); err != nil {
+		return err
+	}
+
+	existing := make([]string, 0, len(existingLabels))
+	for _, label := range existingLabels {
+		existing = append(existing, label.Name)
+	}
+
+	desired := parseLabels(labels)
+	merged := syncChangeLabels(existing, desired, namespacedLabelPrefix(desired))
+	return github.request(http.MethodPut, fmt.Sprintf("/issues/%d/labels", iid), http.StatusOK, merged, nil)
+}
+
+func (github Github) IssuePrefixedLabels(id int, prefix string) ([]string, error) {
+	var existingLabels []struct {
+		Name string `json:"name"`
+	}
+	if err := github.request(http.MethodGet, fmt.Sprintf("/issues/%d/labels", id), http.StatusOK, nil, &existingLabels); err != nil {
+		return nil, fmt.Errorf("unable to get labels for issue %d: %w", id, err)
+	}
+	var out []string
+	for _, label := range existingLabels {
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(label.Name)), strings.ToLower(prefix)) {
+			out = append(out, strings.TrimSpace(label.Name))
+		}
+	}
+	return out, nil
 }
 
 type githubReleaseBody struct {

--- a/internal/github_test.go
+++ b/internal/github_test.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -38,6 +39,7 @@ func TestGithub(t *testing.T) {
 	testmux.HandleFunc("/repos/my/testrepo/pulls", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost {
 			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"number": 4}`)
 			return
 		}
 		if noMrs {
@@ -64,11 +66,31 @@ func TestGithub(t *testing.T) {
 	assert.Equal(t, 3, num)
 
 	testmux.HandleFunc("/repos/my/testrepo/pulls/3", func(w http.ResponseWriter, r *http.Request) {})
+	testmux.HandleFunc("/repos/my/testrepo/issues/3/labels", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			fmt.Fprint(w, `[{"name":"keep-me"},{"name":"change::standard"}]`)
+			return
+		}
+
+		var labels []string
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&labels))
+		assert.Equal(t, []string{"keep-me", "change::major"}, labels)
+	})
+	testmux.HandleFunc("/repos/my/testrepo/issues/4/labels", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			fmt.Fprint(w, `[{"name":"manual"}]`)
+			return
+		}
+
+		var labels []string
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&labels))
+		assert.Equal(t, []string{"manual", "change::major"}, labels)
+	})
 	assert.NoError(t, github.CloseMergeRequest())
 
-	assert.NoError(t, github.MergeRequest("main", "Release v1.2.3", "release description", "tag1,tag2"))
+	assert.NoError(t, github.MergeRequest("main", "Release v1.2.3", "release description", "tag1,tag2,change::major"))
 	noMrs = true
-	assert.NoError(t, github.MergeRequest("main", "Release v1.2.3", "release description", "tag1,tag2"))
+	assert.NoError(t, github.MergeRequest("main", "Release v1.2.3", "release description", "tag1,tag2,change::major"))
 
 	testmux.HandleFunc("/repos/my/testrepo/releases", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusCreated)

--- a/internal/gitlab.go
+++ b/internal/gitlab.go
@@ -57,30 +57,31 @@ func (gitlab Gitlab) request(method, endpoint string, expectedStatus int, body i
 
 var errNoMergeRequestFound = errors.New("no merge request found")
 
-func (gitlab Gitlab) findOpenMergeRequest() (int, error) {
+func (gitlab Gitlab) findOpenMergeRequest() (int, []string, error) {
 	var mrs []struct {
 		ID           int    `json:"id"`
 		IID          int    `json:"iid"`
 		SourceBranch string `json:"source_branch"`
 		State        string `json:"state"`
+		Labels       []string `json:"labels"`
 	}
 
 	if err := gitlab.request(http.MethodGet, fmt.Sprintf("projects/%s/merge_requests?state=opened&source_branch=semanticore%%2frelease", url.PathEscape(gitlab.repo)), http.StatusOK, nil, &mrs); err != nil {
-		return 0, fmt.Errorf("unable to get merge requests: %w", err)
+		return 0, nil, fmt.Errorf("unable to get merge requests: %w", err)
 	}
 
 	for _, mr := range mrs {
 		if mr.SourceBranch == "semanticore/release" && mr.State == "opened" {
 			log.Printf("[gitlab] merge request found: %d", mr.IID)
-			return mr.IID, nil
+			return mr.IID, mr.Labels, nil
 		}
 	}
 
-	return 0, errNoMergeRequestFound
+	return 0, nil, errNoMergeRequestFound
 }
 
 func (gitlab Gitlab) CloseMergeRequest() error {
-	iid, err := gitlab.findOpenMergeRequest()
+	iid, _, err := gitlab.findOpenMergeRequest()
 	if errors.Is(err, errNoMergeRequestFound) {
 		return nil
 	}
@@ -94,7 +95,7 @@ func (gitlab Gitlab) CloseMergeRequest() error {
 }
 
 func (gitlab Gitlab) MergeRequest(target, title, description, labels string) error {
-	iid, err := gitlab.findOpenMergeRequest()
+	iid, existingLabels, err := gitlab.findOpenMergeRequest()
 	if err != nil && !errors.Is(err, errNoMergeRequestFound) {
 		return err
 	}
@@ -106,12 +107,112 @@ func (gitlab Gitlab) MergeRequest(target, title, description, labels string) err
 	data.Set("description", description)
 	data.Set("squash", "true")
 	data.Set("remove_source_branch", "true")
+	if iid > 0 {
+		desired := parseLabels(labels)
+		labels = strings.Join(syncChangeLabels(existingLabels, desired, namespacedLabelPrefix(desired)), ",")
+	}
 	data.Set("labels", labels)
 
 	if iid > 0 {
 		return gitlab.request(http.MethodPut, fmt.Sprintf("projects/%s/merge_requests/%d", url.PathEscape(gitlab.repo), iid), http.StatusOK, strings.NewReader(data.Encode()), nil)
 	}
 	return gitlab.request(http.MethodPost, fmt.Sprintf("projects/%s/merge_requests", url.PathEscape(gitlab.repo)), http.StatusCreated, strings.NewReader(data.Encode()), nil)
+}
+
+func parseLabels(raw string) []string {
+	parts := strings.Split(raw, ",")
+	labels := make([]string, 0, len(parts))
+	for _, part := range parts {
+		label := strings.TrimSpace(part)
+		if label != "" {
+			labels = append(labels, label)
+		}
+	}
+	return labels
+}
+
+// commonLabelPrefix returns the longest common prefix shared by all labels.
+func commonLabelPrefix(labels []string) string {
+	if len(labels) == 0 {
+		return ""
+	}
+	prefix := labels[0]
+	for _, label := range labels[1:] {
+		for !strings.HasPrefix(label, prefix) {
+			if len(prefix) == 0 {
+				return ""
+			}
+			prefix = prefix[:len(prefix)-1]
+		}
+	}
+	return prefix
+}
+
+// namespacedLabelPrefix returns the common namespace prefix (up to and including "::")
+// of all labels that contain "::". Returns "" when no namespaced labels are present.
+func namespacedLabelPrefix(labels []string) string {
+	var ns []string
+	for _, l := range labels {
+		if strings.Contains(l, "::") {
+			ns = append(ns, l)
+		}
+	}
+	prefix := commonLabelPrefix(ns)
+	// truncate to the last "::" boundary so "change::major" → "change::"
+	if idx := strings.LastIndex(prefix, "::"); idx >= 0 {
+		return prefix[:idx+2]
+	}
+	return ""
+}
+
+func syncChangeLabels(existing, desired []string, prefix string) []string {
+	final := make([]string, 0, len(existing)+len(desired))
+	seen := map[string]struct{}{}
+
+	for _, label := range existing {
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(label)), strings.ToLower(prefix)) {
+			continue
+		}
+		normalized := strings.TrimSpace(label)
+		if normalized == "" {
+			continue
+		}
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		final = append(final, normalized)
+	}
+
+	for _, label := range desired {
+		normalized := strings.TrimSpace(label)
+		if !strings.HasPrefix(strings.ToLower(normalized), strings.ToLower(prefix)) {
+			continue
+		}
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		final = append(final, normalized)
+	}
+
+	return final
+}
+
+func (gitlab Gitlab) IssuePrefixedLabels(id int, prefix string) ([]string, error) {
+	var issue struct {
+		Labels []string `json:"labels"`
+	}
+	if err := gitlab.request(http.MethodGet, fmt.Sprintf("projects/%s/issues/%d", url.PathEscape(gitlab.repo), id), http.StatusOK, nil, &issue); err != nil {
+		return nil, fmt.Errorf("unable to get issue %d: %w", id, err)
+	}
+	var out []string
+	for _, label := range issue.Labels {
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(label)), strings.ToLower(prefix)) {
+			out = append(out, strings.TrimSpace(label))
+		}
+	}
+	return out, nil
 }
 
 func (gitlab Gitlab) Release(tag, ref, changelog string) error {

--- a/internal/gitlab_test.go
+++ b/internal/gitlab_test.go
@@ -48,25 +48,33 @@ func TestGitlab(t *testing.T) {
 			"id": 123,
 			"iid": 3,
 			"source_branch": "semanticore/release",
-			"state": "opened"
+			"state": "opened",
+			"labels": ["keep-me", "change::standard"]
 		}]`)
 	})
 
-	num, err := gitlab.findOpenMergeRequest()
+	num, labels, err := gitlab.findOpenMergeRequest()
 	assert.ErrorIs(t, err, errNoMergeRequestFound)
 	assert.Equal(t, 0, num)
+	assert.Nil(t, labels)
 
 	noMrs = false
-	num, err = gitlab.findOpenMergeRequest()
+	num, labels, err = gitlab.findOpenMergeRequest()
 	assert.NoError(t, err)
 	assert.Equal(t, 3, num)
+	assert.Equal(t, []string{"keep-me", "change::standard"}, labels)
 
-	testmux.HandleFunc("/api/v4/projects/my%2ftest%2frepo/merge_requests/3", func(w http.ResponseWriter, r *http.Request) {})
+	testmux.HandleFunc("/api/v4/projects/my%2ftest%2frepo/merge_requests/3", func(w http.ResponseWriter, r *http.Request) {
+		assert.NoError(t, r.ParseForm())
+		if r.Method == http.MethodPut && r.Form.Get("state_event") == "" {
+			assert.Equal(t, "keep-me,change::major", r.Form.Get("labels"))
+		}
+	})
 	assert.NoError(t, gitlab.CloseMergeRequest())
 
-	assert.NoError(t, gitlab.MergeRequest("main", "Release v1.2.3", "release description", "tag1,tag2"))
+	assert.NoError(t, gitlab.MergeRequest("main", "Release v1.2.3", "release description", "tag1,tag2,change::major"))
 	noMrs = true
-	assert.NoError(t, gitlab.MergeRequest("main", "Release v1.2.3", "release description", "tag1,tag2"))
+	assert.NoError(t, gitlab.MergeRequest("main", "Release v1.2.3", "release description", "tag1,tag2,change::major"))
 
 	testmux.HandleFunc("/api/v4/projects/my%2ftest%2frepo/repository/tags", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusCreated)

--- a/internal/repo.go
+++ b/internal/repo.go
@@ -19,6 +19,7 @@ type Repository struct {
 	Major, Minor, Patch int
 	VPrefix             string
 	Latest              string
+	ChangeLabel         string
 
 	fixes       []string
 	Features    []string
@@ -38,11 +39,19 @@ type Repository struct {
 
 	unreleased          string
 	unreleasedChangelog string
+
+	changeLabels map[string]struct{}
+	issueRefs    []int
 }
 
 func ReadRepository(repo *git.Repository, createMajor bool) (*Repository, error) {
+	return ReadRepositoryWithPrefix(repo, createMajor, "")
+}
+
+func ReadRepositoryWithPrefix(repo *git.Repository, createMajor bool, labelPrefix string) (*Repository, error) {
 	repository := &Repository{
-		VPrefix: "v",
+		VPrefix:     "v",
+		changeLabels: map[string]struct{}{},
 	}
 
 	tags := make(map[string][]*plumbing.Reference)
@@ -136,6 +145,21 @@ func ReadRepository(repo *git.Repository, createMajor bool) (*Repository, error)
 			continue
 		}
 		msg := strings.TrimSpace(commit.Message)
+		if labelPrefix != "" {
+			for _, label := range ExtractPrefixedLabels(msg, labelPrefix) {
+				repository.changeLabels[label] = struct{}{}
+			}
+		}
+		seenIssues := map[int]struct{}{}
+		for _, id := range repository.issueRefs {
+			seenIssues[id] = struct{}{}
+		}
+		for _, id := range ExtractIssueRefs(msg) {
+			if _, ok := seenIssues[id]; !ok {
+				repository.issueRefs = append(repository.issueRefs, id)
+				seenIssues[id] = struct{}{}
+			}
+		}
 		if match := reverst.FindStringSubmatch(msg); match != nil {
 			reverted[match[1]] = struct{}{}
 			continue
@@ -251,6 +275,78 @@ func ReadRepository(repo *git.Repository, createMajor bool) (*Repository, error)
 	}
 
 	return repository, nil
+}
+
+func (repository *Repository) CollectIssuePrefixedLabels(backend Backend, prefix string) {
+	for _, id := range repository.issueRefs {
+		labels, err := backend.IssuePrefixedLabels(id, prefix)
+		if err != nil {
+			log.Printf("[semanticore] warning: could not fetch labels for issue #%d: %v", id, err)
+			continue
+		}
+		for _, label := range labels {
+			repository.changeLabels[strings.ToLower(strings.TrimSpace(label))] = struct{}{}
+		}
+	}
+}
+
+// DetermineChangeLabel returns the highest-priority label from the configured priority list
+// that matches any label collected from commits, issues, or the semantic map.
+//
+// defaultLabel is returned when nothing matches at all.
+// It may be an empty string – in that case no label is returned for that case.
+func (repository *Repository) DetermineChangeLabel(priority []string, semanticMap map[string]string, defaultLabel string) string {
+	if len(priority) < 2 {
+		return ""
+	}
+
+	candidates := map[string]struct{}{}
+	for label := range repository.changeLabels {
+		candidates[strings.ToLower(strings.TrimSpace(label))] = struct{}{}
+	}
+
+	for semanticType, label := range semanticMap {
+		if repository.hasSemanticType(semanticType) {
+			candidates[strings.ToLower(strings.TrimSpace(label))] = struct{}{}
+		}
+	}
+
+	for _, label := range priority {
+		normalized := strings.ToLower(strings.TrimSpace(label))
+		if _, ok := candidates[normalized]; ok {
+			return strings.TrimSpace(label)
+		}
+	}
+
+
+	return defaultLabel
+}
+
+func (repository *Repository) hasSemanticType(semanticType string) bool {
+	switch strings.ToLower(strings.TrimSpace(semanticType)) {
+	case "feat", "feature", "features":
+		return len(repository.Features) > 0
+	case "fix", "bug", "bugs":
+		return len(repository.fixes) > 0
+	case "test", "tests":
+		return len(repository.tests) > 0
+	case "chore", "chores", "update", "updates":
+		return len(repository.chores) > 0
+	case "ops", "ci", "cd", "build":
+		return len(repository.ops) > 0
+	case "doc", "docs", "documentation":
+		return len(repository.docs) > 0
+	case "perf", "performance":
+		return len(repository.perf) > 0
+	case "refactor", "rework":
+		return len(repository.refactor) > 0
+	case "sec", "security":
+		return len(repository.security) > 0
+	case "other":
+		return len(repository.other) > 0
+	default:
+		return false
+	}
 }
 
 func (repository *Repository) Release(backend Backend) error {

--- a/internal/repo_test.go
+++ b/internal/repo_test.go
@@ -1,6 +1,9 @@
 package internal
 
 import (
+	"fmt"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/go-git/go-billy/v5/memfs"
@@ -25,9 +28,11 @@ func (b *testBackend) Release(tag, ref, changelog string) error {
 	b.changelog = changelog
 	return nil
 }
-func (*testBackend) MergeRequest(target, title, description, labels string) error { return nil }
-func (*testBackend) CloseMergeRequest() error                                     { return nil }
-func (*testBackend) MainBranch() (string, error)                                  { return "main", nil }
+func (*testBackend) MergeRequest(_, _, _, _ string) error              { return nil }
+func (*testBackend) CloseMergeRequest() error                          { return nil }
+func (*testBackend) MainBranch() (string, error)                       { return "main", nil }
+func (*testBackend) IssuePrefixedLabels(_ int, _ string) ([]string, error) { return nil, nil }
+func (*testBackend) SetAuth(_ *http.Request)                           {}
 
 func TestReadRepository(t *testing.T) {
 	mockRepo, err := git.Init(memory.NewStorage(), memfs.New())
@@ -159,4 +164,100 @@ func TestReadRepository(t *testing.T) {
 	assert.Equal(t, 0, repository.Major)
 	assert.Equal(t, 1, repository.Minor)
 	assert.Equal(t, 0, repository.Patch)
+}
+
+func TestCollectIssuePrefixedLabels(t *testing.T) {
+	priority := []string{"change::emergency", "change::major", "change::normal", "change::standard"}
+
+	backend := &issueBackend{labels: map[int][]string{
+		42:  {"change::major", "other-label"},
+		123: {"change::normal"},
+		99:  nil,
+	}}
+
+	repo := &Repository{
+		changeLabels: map[string]struct{}{},
+		issueRefs:    []int{42, 123, 99, 999},
+	}
+	repo.CollectIssuePrefixedLabels(backend, "change::")
+
+	assert.Equal(t, "change::major", repo.DetermineChangeLabel(priority, nil, "change::standard"))
+}
+
+type issueBackend struct {
+	labels map[int][]string
+}
+
+func (*issueBackend) String() string                                    { return "issueBackend" }
+func (*issueBackend) Name() string                                      { return "issueBackend" }
+func (*issueBackend) SetAuth(_ *http.Request)                           {}
+func (*issueBackend) Release(_, _, _ string) error                     { return nil }
+func (*issueBackend) MergeRequest(_, _, _, _ string) error             { return nil }
+func (*issueBackend) CloseMergeRequest() error                         { return nil }
+func (*issueBackend) MainBranch() (string, error)                      { return "main", nil }
+func (b *issueBackend) IssuePrefixedLabels(id int, prefix string) ([]string, error) {
+	labels, ok := b.labels[id]
+	if !ok {
+		return nil, fmt.Errorf("issue %d not found", id)
+	}
+	var out []string
+	for _, label := range labels {
+		if strings.HasPrefix(strings.ToLower(label), strings.ToLower(prefix)) {
+			out = append(out, label)
+		}
+	}
+	return out, nil
+}
+
+func TestDetermineChangeLabel(t *testing.T) {
+	priority := []string{"change::emergency", "change::major", "change::normal", "change::standard"}
+	dl := "change::standard"
+
+	// explicit label match
+	repo := &Repository{changeLabels: map[string]struct{}{"change::major": {}}}
+	assert.Equal(t, "change::major", repo.DetermineChangeLabel(priority, nil, dl))
+
+	// no feature mapping -> default
+	repo = &Repository{Features: []string{"new feat"}, changeLabels: map[string]struct{}{}}
+	assert.Equal(t, "change::standard", repo.DetermineChangeLabel(priority, nil, dl))
+
+	// feature mapping via semantic map
+	repo = &Repository{Features: []string{"new feat"}, changeLabels: map[string]struct{}{}}
+	assert.Equal(t, "change::normal", repo.DetermineChangeLabel(priority, map[string]string{"feat": "change::normal"}, dl))
+
+	// no match → default
+	repo = &Repository{changeLabels: map[string]struct{}{}}
+	assert.Equal(t, "change::standard", repo.DetermineChangeLabel(priority, nil, dl))
+
+	// no default configured → empty string
+	repo = &Repository{Features: []string{"x"}, changeLabels: map[string]struct{}{}}
+	assert.Equal(t, "", repo.DetermineChangeLabel(priority, nil, ""))
+
+	// semantic map match
+	repo = &Repository{chores: []string{"chore message"}, changeLabels: map[string]struct{}{}}
+	assert.Equal(t, "change::standard", repo.DetermineChangeLabel(priority, map[string]string{"chore": "change::standard"}, dl))
+
+	// explicit label beats lower-priority semantic map entry
+	repo = &Repository{ops: []string{"ops message"}, changeLabels: map[string]struct{}{"change::major": {}}}
+	assert.Equal(t, "change::major", repo.DetermineChangeLabel(priority, map[string]string{"ops": "change::standard"}, dl))
+
+	// 3-label variant with explicit default + map
+	priority3 := []string{"change::emergency", "change::normal", "change::standard"}
+	repo = &Repository{changeLabels: map[string]struct{}{"change::emergency": {}}}
+	assert.Equal(t, "change::emergency", repo.DetermineChangeLabel(priority3, nil, "change::standard"))
+	repo = &Repository{Features: []string{"x"}, changeLabels: map[string]struct{}{}}
+	assert.Equal(t, "change::normal", repo.DetermineChangeLabel(priority3, map[string]string{"feat": "change::normal"}, "change::standard"))
+	repo = &Repository{changeLabels: map[string]struct{}{}}
+	assert.Equal(t, "change::standard", repo.DetermineChangeLabel(priority3, nil, "change::standard"))
+
+	// 5-label variant with custom mapping + explicit default
+	priority5 := []string{"change::emergency", "change::major", "change::normal", "change::minor", "change::standard"}
+	repo = &Repository{Features: []string{"x"}, changeLabels: map[string]struct{}{}}
+	assert.Equal(t, "change::minor", repo.DetermineChangeLabel(priority5, map[string]string{"feat": "change::minor"}, "change::standard"))
+	repo = &Repository{changeLabels: map[string]struct{}{}}
+	assert.Equal(t, "change::standard", repo.DetermineChangeLabel(priority5, nil, "change::standard"))
+
+	// < 2 priority → disabled
+	assert.Equal(t, "", repo.DetermineChangeLabel([]string{"change::major"}, nil, ""))
+	assert.Equal(t, "", repo.DetermineChangeLabel(nil, nil, ""))
 }

--- a/internal/semanticore.go
+++ b/internal/semanticore.go
@@ -10,4 +10,7 @@ type Backend interface {
 	MergeRequest(target, title, description, labels string) error
 	CloseMergeRequest() error
 	MainBranch() (string, error)
+	// IssuePrefixedLabels returns all labels starting with prefix for the given issue number.
+	// Implementations should return nil, nil when issues are not supported or the issue is not found.
+	IssuePrefixedLabels(id int, prefix string) ([]string, error)
 }

--- a/main.go
+++ b/main.go
@@ -38,6 +38,10 @@ var (
 	changelogMaxLines  = flag.Int("changelog-max-lines", 0, "trim the changelog to the last version including the maximum configured lines")
 	changelogFileName  = flag.String("changelog-file-name", emptyFallback(os.Getenv("CHANGELOG_FILE_NAME"), "Changelog.md"), "filename for changelog, falls back to env var CHANGELOG_FILE_NAME and afterwards to \"Changelog.md\"")
 	signKeyFilePath    = flag.String("sign-key-file", emptyFallback(os.Getenv("SEMANTICORE_SIGN_KEY_FILE"), ""), "path to GPG private key file for signing commits")
+	changeLabelsEnabled        = flag.Bool("change-labels-enabled", strings.EqualFold(os.Getenv("SEMANTICORE_CHANGE_LABELS_ENABLED"), "true"), "enable change label sync for merge requests")
+	changeLabels               = flag.String("change-labels", emptyFallback(os.Getenv("SEMANTICORE_CHANGE_LABELS"), ""), "CSV list of labels in priority order (highest first), e.g. change::emergency,change::major,change::normal,change::standard")
+	changeLabelMap             = flag.String("change-label-map", emptyFallback(os.Getenv("SEMANTICORE_CHANGE_LABEL_MAP"), ""), "CSV list mapping semantic commit types to labels, e.g. feat=change::normal,chore=change::standard")
+	changeLabelDefault         = flag.String("change-label-default", emptyFallback(os.Getenv("SEMANTICORE_CHANGE_LABEL_DEFAULT"), ""), "label to use when no commit label matches; must be in --change-labels")
 )
 
 func main() {
@@ -71,7 +75,15 @@ func main() {
 	head, err := repo.Head()
 	try(err)
 
-	repository, err := internal.ReadRepository(repo, *createMajor)
+	// derive label prefix from configured labels when the feature is enabled
+	labelPrefix := ""
+	if *changeLabelsEnabled {
+		if priority, ok := parseChangeLabels(*changeLabels); ok {
+			labelPrefix = commonLabelPrefix(priority)
+		}
+	}
+
+	repository, err := internal.ReadRepositoryWithPrefix(repo, *createMajor, labelPrefix)
 	try(err)
 
 	if backend != nil && *createRelease {
@@ -175,6 +187,24 @@ func main() {
 		releasetype = "minor 📦"
 	}
 	labels := "Release 🏆," + releasetype
+	if *changeLabelsEnabled {
+		if priority, ok := parseChangeLabels(*changeLabels); ok {
+			if backend != nil {
+				repository.CollectIssuePrefixedLabels(backend, labelPrefix)
+			}
+			defaultLabel, defaultOk := parseChangeLabelDefault(*changeLabelDefault, priority)
+			if !defaultOk {
+				log.Printf("[semanticore] change labels are enabled but SEMANTICORE_CHANGE_LABEL_DEFAULT is not part of SEMANTICORE_CHANGE_LABELS, disabling feature")
+			} else if semanticMap, ok := parseChangeLabelMap(*changeLabelMap, priority); ok {
+				repository.ChangeLabel = repository.DetermineChangeLabel(priority, semanticMap, defaultLabel)
+				labels += "," + repository.ChangeLabel
+			} else {
+				log.Printf("[semanticore] change labels are enabled but SEMANTICORE_CHANGE_LABEL_MAP is invalid, disabling feature")
+			}
+		} else {
+			log.Printf("[semanticore] change labels are enabled but SEMANTICORE_CHANGE_LABELS is invalid, disabling feature")
+		}
+	}
 	description := fmt.Sprintf(`# Release %s%d.%d.%d 🏆
 
 ## Summary
@@ -205,3 +235,97 @@ func emptyFallback(s, fallback string) string {
 
 	return s
 }
+
+func parseChangeLabels(raw string) ([]string, bool) {
+	parts := strings.Split(raw, ",")
+	if len(parts) < 2 {
+		return nil, false
+	}
+
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		label := strings.TrimSpace(strings.ToLower(part))
+		if label == "" || !strings.Contains(label, "::") {
+			return nil, false
+		}
+		if _, ok := seen[label]; ok {
+			return nil, false
+		}
+		seen[label] = struct{}{}
+		out = append(out, label)
+	}
+
+	return out, true
+}
+
+// commonLabelPrefix returns the longest common prefix shared by all labels,
+// e.g. ["change::emergency","change::normal"] → "change::".
+// Returns "" if no common prefix exists.
+func commonLabelPrefix(labels []string) string {
+	if len(labels) == 0 {
+		return ""
+	}
+	prefix := labels[0]
+	for _, label := range labels[1:] {
+		for !strings.HasPrefix(label, prefix) {
+			if len(prefix) == 0 {
+				return ""
+			}
+			prefix = prefix[:len(prefix)-1]
+		}
+	}
+	return prefix
+}
+
+// parseChangeLabelDefault validates that defaultLabel is present in the
+// priority list. Empty string is allowed (no default configured).
+func parseChangeLabelDefault(defaultLabel string, priority []string) (string, bool) {
+	allowed := map[string]struct{}{}
+	for _, l := range priority {
+		allowed[strings.ToLower(strings.TrimSpace(l))] = struct{}{}
+	}
+	dl := strings.ToLower(strings.TrimSpace(defaultLabel))
+	if dl != "" {
+		if _, ok := allowed[dl]; !ok {
+			return "", false
+		}
+	}
+	return dl, true
+}
+
+func parseChangeLabelMap(raw string, priority []string) (map[string]string, bool) {
+	allowed := map[string]struct{}{}
+	for _, label := range priority {
+		allowed[strings.ToLower(strings.TrimSpace(label))] = struct{}{}
+	}
+
+	out := map[string]string{}
+	if strings.TrimSpace(raw) == "" {
+		return out, true
+	}
+
+	for _, entry := range strings.Split(raw, ",") {
+		parts := strings.SplitN(entry, "=", 2)
+		if len(parts) != 2 {
+			return nil, false
+		}
+
+		semanticType := strings.ToLower(strings.TrimSpace(parts[0]))
+		label := strings.ToLower(strings.TrimSpace(parts[1]))
+		if semanticType == "" || label == "" {
+			return nil, false
+		}
+		if _, ok := allowed[label]; !ok {
+			return nil, false
+		}
+		if _, ok := out[semanticType]; ok {
+			return nil, false
+		}
+
+		out[semanticType] = label
+	}
+
+	return out, true
+}
+

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseChangeLabels(t *testing.T) {
+	// standard 4-label config
+	labels, ok := parseChangeLabels("change::emergency,change::major,change::normal,change::standard")
+	assert.True(t, ok)
+	assert.Equal(t, []string{"change::emergency", "change::major", "change::normal", "change::standard"}, labels)
+
+	// 3 labels
+	labels, ok = parseChangeLabels("change::emergency,change::normal,change::standard")
+	assert.True(t, ok)
+	assert.Equal(t, []string{"change::emergency", "change::normal", "change::standard"}, labels)
+
+	// 5 labels
+	labels, ok = parseChangeLabels("change::emergency,change::major,change::normal,change::minor,change::standard")
+	assert.True(t, ok)
+	assert.Len(t, labels, 5)
+
+	// minimum: exactly 2 labels
+	labels, ok = parseChangeLabels("change::important,change::standard")
+	assert.True(t, ok)
+	assert.Equal(t, []string{"change::important", "change::standard"}, labels)
+
+	// too few: only 1 label
+	_, ok = parseChangeLabels("change::emergency")
+	assert.False(t, ok)
+
+	// empty
+	_, ok = parseChangeLabels("")
+	assert.False(t, ok)
+
+	// duplicates
+	_, ok = parseChangeLabels("change::emergency,change::major,change::normal,change::normal")
+	assert.False(t, ok)
+
+	// labels without :: separator
+	_, ok = parseChangeLabels("emergency,major,normal,standard")
+	assert.False(t, ok)
+}
+
+func TestParseChangeLabelDefault(t *testing.T) {
+	priority := []string{"change::emergency", "change::major", "change::normal", "change::standard"}
+
+	dl, ok := parseChangeLabelDefault("change::standard", priority)
+	assert.True(t, ok)
+	assert.Equal(t, "change::standard", dl)
+
+	// empty string is valid (no fallback)
+	dl, ok = parseChangeLabelDefault("", priority)
+	assert.True(t, ok)
+	assert.Equal(t, "", dl)
+
+	// label not in priority list
+	_, ok = parseChangeLabelDefault("change::unknown", priority)
+	assert.False(t, ok)
+}
+
+func TestParseChangeLabelMap(t *testing.T) {
+	priority := []string{"change::emergency", "change::major", "change::normal", "change::standard"}
+
+	mapping, ok := parseChangeLabelMap("feat=change::normal,chore=change::standard,ops=change::standard", priority)
+	assert.True(t, ok)
+	assert.Equal(t, map[string]string{
+		"feat":  "change::normal",
+		"chore": "change::standard",
+		"ops":   "change::standard",
+	}, mapping)
+
+	mapping, ok = parseChangeLabelMap("", priority)
+	assert.True(t, ok)
+	assert.Empty(t, mapping)
+
+	_, ok = parseChangeLabelMap("feat=change::normal,feat=change::standard", priority)
+	assert.False(t, ok)
+
+	_, ok = parseChangeLabelMap("feat=change::critical", priority)
+	assert.False(t, ok)
+
+	_, ok = parseChangeLabelMap("feat-change::normal", priority)
+	assert.False(t, ok)
+}
+


### PR DESCRIPTION
In order to implement some change management related labels along with the semanticore merge requests this adds support to use a set of labels which are deducted from the related commits and issues.

